### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,41 +199,12 @@
 
 	<dependencies>
 
-		<dependency>
-			<groupId>xml-apis</groupId>
-			<artifactId>xml-apis</artifactId>
-			<version>1.4.01</version>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.jsoup</groupId>
-			<artifactId>jsoup</artifactId>
-			<version>1.7.3</version>
-		</dependency>
-		<dependency>
-			<groupId>us.codecraft</groupId>
-			<artifactId>xsoup</artifactId>
-			<version>0.3.0</version>
-		</dependency>
-
-	
-
-		<!-- Suite of Java SSH applications providing a Java SSH API, SSH Terminal, 
-			SSH secured VNC client, SFTP client and SSH Daemon -->
-		<dependency>
-			<groupId>sshtools</groupId>
-			<artifactId>j2ssh-core</artifactId>
-			<version>0.2.9</version>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/com.hierynomus/sshj -->
-		<dependency>
-			<groupId>com.hierynomus</groupId>
-			<artifactId>sshj</artifactId>
-			<version>0.30.0</version>
-		</dependency>
-
-		<!-- TestNG framework -->
+		
+		
+		
+		
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
@@ -243,58 +214,17 @@
 		<!-- ReportNG, a simple HTML reporting plug-in for the TestNG unit-testing 
 			framework Usually in our project newer TestNG version is used, so that ReportNG 
 			dependency should be excluded -->
-		<dependency>
-			<groupId>org.uncommons</groupId>
-			<artifactId>reportng</artifactId>
-			<version>1.1.4</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.testng</groupId>
-					<artifactId>testng</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>velocity</groupId>
-			<artifactId>velocity</artifactId>
-			<version>1.5</version>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>com.google.inject</groupId>
-			<artifactId>guice</artifactId>
-			<version>3.0</version>
-		</dependency>
+		
+		
+		
 
-		<!-- Selenium Server Standalone -->
-		<dependency>
-        	<groupId>org.seleniumhq.selenium</groupId>
-        	<artifactId>selenium-java</artifactId>
-			<version>${selenium.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-support</artifactId>
-			<version>3.3.1</version>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-			<version>1.3.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.3</version>
-		</dependency>
-
-
-		<!-- OBTAINING SPRING RELEASES FROM MANEN CENTRAL -->
-
-		<!-- Core utilities used by other modules. -->
+		
 		<dependency>
                 <groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
@@ -302,13 +232,7 @@
 		</dependency>
 
 		<!-- Expression Language (depends on spring-core) -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-expression</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-
-		<!-- Bean Factory and JavaBeans utilities (depends on spring-core) -->
+		
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
@@ -317,14 +241,7 @@
 
 		<!-- Aspect Oriented Programming (AOP) Framework (depends on spring-core, 
 			spring-beans) -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aop</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-
-		<!-- Application Context (depends on spring-core, spring-expression, spring-aop, 
-			spring-beans) -->
+		
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
@@ -333,29 +250,9 @@
 
 		<!-- Various Application Context utilities, including EhCache, JavaMail, 
 			Quartz, and Freemarker integration -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context-support</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-
-		<!-- Transaction Management Abstraction (depends on spring-core, spring-beans, 
-			spring-aop, spring-context) -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-tx</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-
-		<!-- JDBC Data Access Library (depends on spring-core, spring-beans, spring-context, 
-			spring-tx) -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-
-		<!-- spring mvc -->
+		
+		
+		
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
@@ -363,16 +260,8 @@
 		</dependency>
 
 		<!-- AspectJ -->
-		<dependency>
-			<groupId>org.aspectj</groupId>
-			<artifactId>aspectjrt</artifactId>
-			<version>1.7.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.aspectj</groupId>
-			<artifactId>aspectjweaver</artifactId>
-			<version>1.7.4</version>
-		</dependency>
+		
+		
 
 		<dependency>
 			<groupId>javassist</groupId>
@@ -397,48 +286,21 @@
 			</exclusions>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-instrument</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
+		
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>
 		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
-			<scope>test</scope>
-		</dependency>
+		
 
 
-		<dependency>
-			<groupId>org.fusesource.mqtt-client</groupId>
-			<artifactId>mqtt-client</artifactId>
-			<version>1.3</version>
-		</dependency>
+		
+		
 
-		<!-- apparently this fixes 2.46.0 -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-exec</artifactId>
-			<version>1.3</version>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.0</version>
-		</dependency>
+		
 	</dependencies>
 
 


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
stevia-core
{groupId='xml-apis', artifactId='xml-apis'}
{groupId='org.jsoup', artifactId='jsoup'}
{groupId='us.codecraft', artifactId='xsoup'}
{groupId='sshtools', artifactId='j2ssh-core'}
{groupId='com.hierynomus', artifactId='sshj'}
{groupId='org.uncommons', artifactId='reportng'}
{groupId='velocity', artifactId='velocity'}
{groupId='com.google.inject', artifactId='guice'}
{groupId='org.seleniumhq.selenium', artifactId='selenium-java'}
{groupId='org.seleniumhq.selenium', artifactId='selenium-support'}
{groupId='javax.annotation', artifactId='javax.annotation-api'}
{groupId='joda-time', artifactId='joda-time'}
{groupId='org.springframework', artifactId='spring-expression'}
{groupId='org.springframework', artifactId='spring-aop'}
{groupId='org.springframework', artifactId='spring-context-support'}
{groupId='org.springframework', artifactId='spring-tx'}
{groupId='org.springframework', artifactId='spring-jdbc'}
{groupId='org.aspectj', artifactId='aspectjrt'}
{groupId='org.aspectj', artifactId='aspectjweaver'}
{groupId='org.springframework', artifactId='spring-instrument'}
{groupId='ch.qos.logback', artifactId='logback-classic'}
{groupId='org.fusesource.mqtt-client', artifactId='mqtt-client'}
{groupId='org.apache.commons', artifactId='commons-exec'}
{groupId='commons-io', artifactId='commons-io'}
{groupId='org.apache.commons', artifactId='commons-lang3'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
